### PR TITLE
Remove AUTHENTICATION_REQUIRED error code

### DIFF
--- a/code/API_definitions/device-reachability-status-subscriptions.yaml
+++ b/code/API_definitions/device-reachability-status-subscriptions.yaml
@@ -1215,20 +1215,13 @@ components:
                   code:
                     enum:
                       - UNAUTHENTICATED
-                      - AUTHENTICATION_REQUIRED
           examples:
             GENERIC_401_UNAUTHENTICATED:
-              description: Request cannot be authenticated
+              description: Request cannot be authenticated and a new authentication is required
               value:
                 status: 401
                 code: UNAUTHENTICATED
-                message: Request not authenticated due to missing, invalid, or expired credentials.
-            GENERIC_401_AUTHENTICATION_REQUIRED:
-              description: New authentication is needed, authentication is no longer valid
-              value:
-                status: 401
-                code: AUTHENTICATION_REQUIRED
-                message: New authentication is required.
+                message: Request not authenticated due to missing, invalid, or expired credentials. A new authentication is required.
 
     Generic403:
       description: Client does not have sufficient permission

--- a/code/API_definitions/device-reachability-status.yaml
+++ b/code/API_definitions/device-reachability-status.yaml
@@ -347,20 +347,14 @@ components:
                   code:
                     enum:
                       - UNAUTHENTICATED
-                      - AUTHENTICATION_REQUIRED
           examples:
             GENERIC_401_UNAUTHENTICATED:
-              description: Request cannot be authenticated
+              description: Request cannot be authenticated and a new authentication is required
               value:
                 status: 401
                 code: UNAUTHENTICATED
-                message: Request not authenticated due to missing, invalid, or expired credentials.
-            GENERIC_401_AUTHENTICATION_REQUIRED:
-              description: New authentication is needed, authentication is no longer valid
-              value:
-                status: 401
-                code: AUTHENTICATION_REQUIRED
-                message: New authentication is required.
+                message: Request not authenticated due to missing, invalid, or expired credentials. A new authentication is required.
+
     Generic403:
       description: Forbidden
       headers:

--- a/code/Test_definitions/device-reachability-status-subscriptions.feature
+++ b/code/Test_definitions/device-reachability-status-subscriptions.feature
@@ -416,7 +416,7 @@ Feature: Device Reachability Status Subscriptions API, v0.7.0 - Operations creat
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   @reachability_status_subscriptions_creation_401.2_expired_access_token
@@ -427,7 +427,7 @@ Feature: Device Reachability Status Subscriptions API, v0.7.0 - Operations creat
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   @reachability_status_subscriptions_creation_401.3_malformed_access_token
@@ -438,7 +438,7 @@ Feature: Device Reachability Status Subscriptions API, v0.7.0 - Operations creat
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   @reachability_status_subscriptions_retrieve_401.4_no_authorization_header
@@ -448,7 +448,7 @@ Feature: Device Reachability Status Subscriptions API, v0.7.0 - Operations creat
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   @reachability_status_subscriptions_retrieve_401.5_expired_access_token
@@ -458,7 +458,7 @@ Feature: Device Reachability Status Subscriptions API, v0.7.0 - Operations creat
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   @reachability_status_subscriptions_retrieve_401.6_malformed_access_token
@@ -468,7 +468,7 @@ Feature: Device Reachability Status Subscriptions API, v0.7.0 - Operations creat
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   @reachability_status_subscriptions_delete_401.7_no_authorization_header
@@ -478,7 +478,7 @@ Feature: Device Reachability Status Subscriptions API, v0.7.0 - Operations creat
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   @reachability_status_subscriptions_delete_401.8_expired_access_token
@@ -488,7 +488,7 @@ Feature: Device Reachability Status Subscriptions API, v0.7.0 - Operations creat
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   @reachability_status_subscriptions_delete_401.9_malformed_access_token
@@ -498,7 +498,7 @@ Feature: Device Reachability Status Subscriptions API, v0.7.0 - Operations creat
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   @reachability_status_subscriptions_retrieve__list_401.10_no_authorization_header
@@ -508,7 +508,7 @@ Feature: Device Reachability Status Subscriptions API, v0.7.0 - Operations creat
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   @reachability_status_subscriptions_retrieve_list_401.11_expired_access_token
@@ -518,7 +518,7 @@ Feature: Device Reachability Status Subscriptions API, v0.7.0 - Operations creat
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   @reachability_status_subscriptions_retrieve_list_401.12_malformed_access_token
@@ -528,7 +528,7 @@ Feature: Device Reachability Status Subscriptions API, v0.7.0 - Operations creat
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
 ##################

--- a/code/Test_definitions/device-reachability-status.feature
+++ b/code/Test_definitions/device-reachability-status.feature
@@ -185,7 +185,7 @@ Feature: CAMARA Device reachability status API, v1.0.0 - Operation getReachabili
     When the request "getReachabilityStatus" is sent
     Then the response status code is 401
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   @device_reachability_status_401.2_no_authorization_header
@@ -195,7 +195,7 @@ Feature: CAMARA Device reachability status API, v1.0.0 - Operation getReachabili
     When the request "getReachabilityStatus" is sent
     Then the response status code is 401
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   @device_reachability_status_401.3_malformed_access_token
@@ -206,7 +206,7 @@ Feature: CAMARA Device reachability status API, v1.0.0 - Operation getReachabili
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
 #################


### PR DESCRIPTION
#### What type of PR is this?
* correction

#### What this PR does / why we need it:
Commonalities pre-release [r3.1](https://github.com/camaraproject/Commonalities/releases/tag/r3.1) removes the `AUTHENTICATION_REQUIRED` error code, leaving `UNAUTHENTICATED` as the only valid error code when the HTTP status code is 401.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #6 

#### Special notes for reviewers:
This is not a breaking change

#### Changelog input
```
 release-note
 - Remove AUTHENTICATION_REQUIRED error code
```

#### Additional documentation 
None