### PR TITLE
Make lastStatusTime mandatory in 200 responses of the API

### DIFF
--- a/code/API_definitions/device-reachability-status.yaml
+++ b/code/API_definitions/device-reachability-status.yaml
@@ -19,7 +19,7 @@ info:
 
     * **Connectivity:** Indicates the connectivity types (DATA, SMS or both) through which the device is reachable from the network.
 
-    * **LastStatusTime** : This property specifies the time when the status was last updated. Its presence in the response indicates the freshness of the information, while its absence implies the information may be outdated or its freshness is uncertain.
+    * **LastStatusTime** : The time when the status was last confirmed to be correct. An older status is more likely to now be incorrect.
 
     # API Functionality
 
@@ -179,6 +179,7 @@ components:
     ReachabilityStatusResponse:
       type: object
       required:
+        - lastStatusTime
         - reachable
       properties:
         lastStatusTime:

--- a/code/Test_definitions/device-reachability-status.feature
+++ b/code/Test_definitions/device-reachability-status.feature
@@ -34,7 +34,7 @@ Feature: CAMARA Device reachability status API, vwip - Operation getReachability
     And the response body complies with the OAS schema at "#/components/schemas/ReachabilityStatusResponse"
     And the response property "$.reachable" is true
     And the response property "$.connectivity" includes "SMS"
-    And if the response property "$.lastStatusTime" is present, then the value has a valid date-time format
+    And the response property "$.lastStatusTime" is present and has a valid date-time format for a time in the past
 
   @device_reachability_status_02_reachable_and_connected_data
   Scenario: Check the reachability status if device is connected with DATA
@@ -48,7 +48,7 @@ Feature: CAMARA Device reachability status API, vwip - Operation getReachability
     And the response body complies with the OAS schema at "#/components/schemas/ReachabilityStatusResponse"
     And the response property "$.reachable" is true
     And the response property "$.connectivity" includes "DATA"
-    And if the response property "$.lastStatusTime" is present, then the value has a valid date-time format
+    And the response property "$.lastStatusTime" is present and has a valid date-time format for a time in the past
 
   @device_reachability_status_03_reachable_and_connected_data_and_sms
   Scenario: Check the reachability status if device is connected with DATA and SMS
@@ -62,7 +62,7 @@ Feature: CAMARA Device reachability status API, vwip - Operation getReachability
     And the response body complies with the OAS schema at "#/components/schemas/ReachabilityStatusResponse"
     And the response property "$.reachable" is true
     And the response property "$.connectivity" includes both "DATA" and "SMS"
-    And if the response property "$.lastStatusTime" is present, then the value has a valid date-time format
+    And the response property "$.lastStatusTime" is present and has a valid date-time format for a time in the past
 
   @device_reachability_status_04_not_reachable
   Scenario: Check the reachability status for an unreachable device
@@ -74,7 +74,7 @@ Feature: CAMARA Device reachability status API, vwip - Operation getReachability
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "#/components/schemas/ReachabilityStatusResponse"
     And the response property "$.reachable" is false
-    And if the response property "$.lastStatusTime" is present, then the value has a valid date-time format
+    And the response property "$.lastStatusTime" is present and has a valid date-time format for a time in the past
     And the response property "$.connectivity" is not present
 
 #################


### PR DESCRIPTION
#### What type of PR is this?
* enhancement/feature

#### What this PR does / why we need it:
This PR makes property `lastStatusTime` mandatory in 200 responses of the API

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #10 

#### Special notes for reviewers:
This is not a breaking change for the client

#### Changelog input
```
 release-note
 - Make lastStatusTime mandatory in 200 responses of the API
```

#### Additional documentation 
None