### PR TITLE
Update OAS and test definitions to remove IDENTIFIER_MISMATCH error code

### DIFF
--- a/code/API_definitions/device-reachability-status-subscriptions.yaml
+++ b/code/API_definitions/device-reachability-status-subscriptions.yaml
@@ -13,7 +13,10 @@ info:
     # Relevant terms and definitions
 
     * **Device**: A device refers to any physical entity that can connect to a network and participate in network communication.
-      At least one identifier for the device (user equipment) out of four options: IPv4 address, IPv6 address, Phone number, or Network Access Identifier (not supported for this API version) assigned by the mobile network operator for the device.
+
+        At least one identifier for the device out of four options must be provided: IPv4 address, IPv6 address, Phone number, or Network Access Identifier assigned by the mobile network operator for the device. Where more than one device identifier is provided, only one identifier will be selected by the implementation and this choice indicated to the API consumer in the session creation response.
+
+        Note: Network Access Identifier is defined for future use and will not be supported with this version of the API.
 
     # API Functionality
 
@@ -209,8 +212,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/Subscription"
               examples:
-                subscription-active:
-                  $ref: "#/components/examples/SUBSCRIPTION_ACTIVE"
+                Active Subscription:
+                  $ref: "#/components/examples/ACTIVE_SUBSCRIPTION"
+                Active Subscription With Device Disambiguation:
+                  $ref: "#/components/examples/ACTIVE_SUBSCRIPTION_WITH_DEVICE_DISAMBIGUATION"
         "202":
           description: Request accepted to be processed. It applies for async creation process.
           headers:
@@ -257,6 +262,11 @@ paths:
                 minItems: 0
                 items:
                   $ref: "#/components/schemas/Subscription"
+              examples:
+                List of Subscriptions:
+                  $ref: "#/components/examples/SUBSCRIPTION_LIST"
+                Empty List of Subscriptions:
+                  $ref: "#/components/examples/EMPTY_SUBSCRIPTION_LIST"
         "400":
           $ref: "#/components/responses/Generic400"
         "401":
@@ -288,11 +298,13 @@ paths:
               schema:
                 $ref: "#/components/schemas/Subscription"
               examples:
-                subscription-active:
-                  $ref: "#/components/examples/SUBSCRIPTION_ACTIVE"
-                subscription-activation-requested:
+                Active Subscription:
+                  $ref: "#/components/examples/ACTIVE_SUBSCRIPTION"
+                Active Subscription With Device Disambiguation:
+                  $ref: "#/components/examples/ACTIVE_SUBSCRIPTION_WITH_DEVICE_DISAMBIGUATION"
+                Subscription Activation Requested:
                   $ref: "#/components/examples/SUBSCRIPTION_ACTIVATION_REQUESTED"
-                subscription-deleted:
+                Subscription Deleted:
                   $ref: "#/components/examples/SUBSCRIPTION_DELETED"
 
         "400":
@@ -723,6 +735,16 @@ components:
           $ref: "#/components/schemas/DeviceIpv6Address"
       minProperties: 1
 
+    DeviceResponse:
+      description: |
+        An identifier for the end-user equipment able to connect to the network that the response refers to. This parameter is only returned when the API consumer includes the `device` parameter in their request (i.e. they are using a two-legged access token), and is relevant when more than one device identifier is specified, as only one of those device identifiers is allowed in the response.
+
+        If the API consumer provides more than one device identifier in their request, the API provider must return a single identifier which is the one they are using to fulfil the request, even if the identifiers do not match the same device. API provider does not perform any logic to validate/correlate that the indicated device identifiers match the same device. No error should be returned if the identifiers are otherwise valid to prevent API consumers correlating different identifiers with a given end user.
+
+      allOf:
+        - $ref: "#/components/schemas/Device"
+        - maxProperties: 1
+
     PhoneNumber:
       description: A public identifier addressing a telephone subscription. In mobile networks it corresponds to the MSISDN (Mobile Station International Subscriber Directory Number). In order to be globally unique it has to be formatted in international format, according to E.164 standard, prefixed with '+'.
       type: string
@@ -888,7 +910,7 @@ components:
         - subscriptionId
       properties:
         device:
-          $ref: "#/components/schemas/Device"
+          $ref: "#/components/schemas/DeviceResponse"
         subscriptionId:
           $ref: "#/components/schemas/SubscriptionId"
 
@@ -909,7 +931,7 @@ components:
         - subscriptionId
       properties:
         device:
-          $ref: "#/components/schemas/Device"
+          $ref: "#/components/schemas/DeviceResponse"
         terminationReason:
           $ref: "#/components/schemas/TerminationReason"
         subscriptionId:
@@ -1384,19 +1406,12 @@ components:
                       - 422
                   code:
                     enum:
-                      - IDENTIFIER_MISMATCH
                       - SERVICE_NOT_APPLICABLE
                       - MISSING_IDENTIFIER
                       - UNSUPPORTED_IDENTIFIER
                       - UNNECESSARY_IDENTIFIER
                       - MULTIEVENT_SUBSCRIPTION_NOT_SUPPORTED
           examples:
-            GENERIC_422_IDENTIFIER_MISMATCH:
-              description: Inconsistency between identifiers not pointing to the same device
-              value:
-                status: 422
-                code: IDENTIFIER_MISMATCH
-                message: Provided identifiers are not consistent.
             GENERIC_422_SERVICE_NOT_APPLICABLE:
               description: Service not applicable for the provided identifier
               value:
@@ -1516,7 +1531,23 @@ components:
           terminationDescription: Subscription expiry time has been reached
         time: "2024-03-22T05:40:23.682Z"
 
-    SUBSCRIPTION_ACTIVE:
+    ACTIVE_SUBSCRIPTION:
+      value:
+        id: 550e8400-e29b-41d4-a716-446655440000
+        sink: https://endpoint.example.com/sink
+        protocol: HTTP
+        types:
+          - "org.camaraproject.device-reachability-status-subscriptions.v0.reachability-data"
+        config:
+          subscriptionDetail: {}
+          subscriptionExpireTime: "2024-07-17T13:18:23.682Z"
+          subscriptionMaxEvents: 5
+          initialEvent: true
+        startsAt: "2024-07-03T21:12:02.871Z"
+        expiresAt: "2024-07-03T21:12:02.871Z"
+        status: ACTIVE
+
+    ACTIVE_SUBSCRIPTION_WITH_DEVICE_DISAMBIGUATION:
       value:
         id: 550e8400-e29b-41d4-a716-446655440000
         sink: https://endpoint.example.com/sink
@@ -1542,9 +1573,7 @@ components:
         types:
           - "org.camaraproject.device-reachability-status-subscriptions.v0.reachability-data"
         config:
-          subscriptionDetail:
-            device:
-              phoneNumber: "+123456789"
+          subscriptionDetail: {}
           subscriptionExpireTime: "2024-07-17T13:18:23.682Z"
           subscriptionMaxEvents: 5
           initialEvent: true
@@ -1593,3 +1622,24 @@ components:
           "subscriptionMaxEvents": 5,
           "initialEvent": true
         }
+
+    SUBSCRIPTION_LIST:
+      description: A list of API consumer subscriptions. If a 3-legged access token is used, the list is specific to the device associated with that token.
+      value:
+        - id: 550e8400-e29b-41d4-a716-446655440000
+          sink: https://endpoint.example.com/sink
+          protocol: HTTP
+          types:
+            - "org.camaraproject.device-reachability-status-subscriptions.v0.reachability-data"
+          config:
+            subscriptionDetail: {}
+            subscriptionExpireTime: "2024-07-17T13:18:23.682Z"
+            subscriptionMaxEvents: 5
+            initialEvent: true
+          startsAt: "2024-07-03T21:12:02.871Z"
+          expiresAt: "2024-07-03T21:12:02.871Z"
+          status: ACTIVE
+
+    EMPTY_SUBSCRIPTION_LIST:
+      description: The API consumer either has no subscriptions or, if a 3-legged access token is used, has none for the device associated with that token.
+      value: []

--- a/code/API_definitions/device-reachability-status-subscriptions.yaml
+++ b/code/API_definitions/device-reachability-status-subscriptions.yaml
@@ -1589,9 +1589,7 @@ components:
         types:
           - "org.camaraproject.device-reachability-status-subscriptions.v0.reachability-data"
         config:
-          subscriptionDetail:
-            device:
-              phoneNumber: "+123456789"
+          subscriptionDetail: {}
           subscriptionExpireTime: "2024-07-17T13:18:23.682Z"
           subscriptionMaxEvents: 5
           initialEvent: true

--- a/code/API_definitions/device-reachability-status.yaml
+++ b/code/API_definitions/device-reachability-status.yaml
@@ -130,12 +130,12 @@ paths:
                     lastStatusTime: "2024-02-20T10:41:38.657Z"
                     reachable: true
                     connectivity: ["SMS"]
-                Reachable Using data:
+                Reachable Using Data:
                   value:
                     lastStatusTime: "2024-02-20T10:41:38.657Z"
                     reachable: true
                     connectivity: ["DATA"]
-                Reachable Using data and SMS:
+                Reachable Using Data and SMS:
                   value:
                     lastStatusTime: "2024-02-20T10:41:38.657Z"
                     reachable: true

--- a/code/API_definitions/device-reachability-status.yaml
+++ b/code/API_definitions/device-reachability-status.yaml
@@ -13,7 +13,10 @@ info:
     ## Relevant terms and definitions
 
     * **Device**: A device refers to any physical entity that can connect to a network and participate in network communication.
-      At least one identifier for the device (user equipment) out of four options: IPv4 address, IPv6 address, Phone number, or Network Access Identifier (not supported for this API version) assigned by the mobile network operator for the device.
+
+        At least one identifier for the device (user equipment) out of four options must be provided: IPv4 address, IPv6 address, Phone number, or Network Access Identifier assigned by the mobile network operator for the device. Where more than one device identifier is provided, only one identifier will be selected by the implementation and this choice indicated to the API consumer in the session creation response.
+
+        Note: Network Access Identifier is defined for future use and will not be supported with this version of the API.
 
     * **Reachable:** Indicates, if the device is reachable from the network or not.
 
@@ -115,23 +118,29 @@ paths:
               schema:
                 $ref: "#/components/schemas/ReachabilityStatusResponse"
               examples:
-                Connected-With-SMS:
+                Reachable Using SMS:
                   value:
                     lastStatusTime: "2024-02-20T10:41:38.657Z"
                     reachable: true
                     connectivity: ["SMS"]
-                Connected-With-DATA:
+                Reachable Using SMS With Device Disambguation:
+                  value:
+                    device:
+                      phoneNumber: "+123456789"
+                    lastStatusTime: "2024-02-20T10:41:38.657Z"
+                    reachable: true
+                    connectivity: ["SMS"]
+                Reachable Using data:
                   value:
                     lastStatusTime: "2024-02-20T10:41:38.657Z"
                     reachable: true
                     connectivity: ["DATA"]
-
-                Connected-With-DATA-And-SMS:
+                Reachable Using data and SMS:
                   value:
                     lastStatusTime: "2024-02-20T10:41:38.657Z"
                     reachable: true
                     connectivity: ["DATA", "SMS"]
-                Not-Reachable:
+                Not Reachable Over The Mobile Network:
                   value:
                     lastStatusTime: "2024-02-20T10:41:38.657Z"
                     reachable: false
@@ -176,12 +185,15 @@ components:
       type: string
       format: date-time
       example: "2024-02-20T10:41:38.657Z"
+
     ReachabilityStatusResponse:
       type: object
       required:
         - lastStatusTime
         - reachable
       properties:
+        device:
+          $ref: "#/components/schemas/DeviceResponse"
         lastStatusTime:
           $ref: "#/components/schemas/LastStatusTime"
         reachable:
@@ -191,6 +203,7 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/ConnectivityType"
+
     ConnectivityType:
       description: |
         DATA: The device is connected to the network for Data usage (regardless of the SMS reachability)
@@ -201,6 +214,7 @@ components:
       enum:
         - DATA
         - SMS
+
     Device:
       description: |
         End-user equipment able to connect to a mobile network. Examples of devices include smartphones or IoT sensors/actuators.
@@ -224,6 +238,16 @@ components:
         ipv6Address:
           $ref: "#/components/schemas/DeviceIpv6Address"
       minProperties: 1
+
+    DeviceResponse:
+      description: |
+        An identifier for the end-user equipment able to connect to the network that the response refers to. This parameter is only returned when the API consumer includes the `device` parameter in their request (i.e. they are using a two-legged access token), and is relevant when more than one device identifier is specified, as only one of those device identifiers is allowed in the response.
+
+        If the API consumer provides more than one device identifier in their request, the API provider must return a single identifier which is the one they are using to fulfil the request, even if the identifiers do not match the same device. API provider does not perform any logic to validate/correlate that the indicated device identifiers match the same device. No error should be returned if the identifiers are otherwise valid to prevent API consumers correlating different identifiers with a given end user.
+
+      allOf:
+        - $ref: "#/components/schemas/Device"
+        - maxProperties: 1
 
     PhoneNumber:
       description: A public identifier addressing a telephone subscription. In mobile networks it corresponds to the MSISDN (Mobile Station International Subscriber Directory Number). In order to be globally unique it has to be formatted in international format, according to E.164 standard, prefixed with '+'.
@@ -430,18 +454,11 @@ components:
                       - 422
                   code:
                     enum:
-                      - IDENTIFIER_MISMATCH
                       - SERVICE_NOT_APPLICABLE
                       - MISSING_IDENTIFIER
                       - UNSUPPORTED_IDENTIFIER
                       - UNNECESSARY_IDENTIFIER
           examples:
-            GENERIC_422_IDENTIFIER_MISMATCH:
-              description: Inconsistency between identifiers not pointing to the same device
-              value:
-                status: 422
-                code: IDENTIFIER_MISMATCH
-                message: Provided identifiers are not consistent.
             GENERIC_422_SERVICE_NOT_APPLICABLE:
               description: Service not applicable for the provided identifier
               value:

--- a/code/Test_definitions/device-reachability-status-subscriptions.feature
+++ b/code/Test_definitions/device-reachability-status-subscriptions.feature
@@ -326,19 +326,6 @@ Feature: Device Reachability Status Subscriptions API, vwip - Operations createD
     And the response property "$.code" is "SERVICE_NOT_APPLICABLE"
     And the response property "$.message" contains a user-friendly text
 
-  # Several identifiers provided but they do not identify the same device
-  # This scenario may happen with 2-legged access tokens, which do not identify a device
-  @reachability_status_subscriptions_C01.08_device_identifiers_mismatch
-  Scenario: Device identifiers mismatch
-    Given the header "Authorization" is set to a valid access token which does not identify a single device
-    And at least 2 types of device identifiers are supported by the implementation
-    And the request body property "$.device" includes several identifiers, each of them identifying a valid but different device
-    When the request "createDeviceReachabilityStatusSubscription" is sent
-    Then the response status code is 422
-    And the response property "$.status" is 422
-    And the response property "$.code" is "IDENTIFIER_MISMATCH"
-    And the response property "$.message" contains a user friendly text
-
 ##################
 # Error code 400
 ##################

--- a/code/Test_definitions/device-reachability-status.feature
+++ b/code/Test_definitions/device-reachability-status.feature
@@ -161,19 +161,6 @@ Feature: CAMARA Device reachability status API, vwip - Operation getReachability
     And the response property "$.code" is "SERVICE_NOT_APPLICABLE"
     And the response property "$.message" contains a user-friendly text
 
-  # Several identifiers provided but they do not identify the same device
-  # This scenario may happen with 2-legged access tokens, which do not identify a device
-  @device_reachability_status_C01.08_device_identifiers_mismatch
-  Scenario: Device identifiers mismatch
-    Given the header "Authorization" is set to a valid access token which does not identify a single device
-    And at least 2 types of device identifiers are supported by the implementation
-    And the request body property "$.device" includes several identifiers, each of them identifying a valid but different device
-    When the request "getReachabilityStatus" is sent
-    Then the response status code is 422
-    And the response property "$.status" is 422
-    And the response property "$.code" is "IDENTIFIER_MISMATCH"
-    And the response property "$.message" contains a user friendly text
-
 #################
 # Error code 401
 #################


### PR DESCRIPTION
#### What type of PR is this?
* correction

#### What this PR does / why we need it:
Commonalities has removed the `IDENTIFIER_MISMATCH` error for Fall25. Instead, a device identifier should not normally be included in responses. It should only be included to disambiguate the identity of the device when:
- the endpoint is being accessed using a 2-legged access token; and
- the endpoint allows for a device identifier to be provided in the request; and
- the API consumer has included multiple device identifiers

The response then includes the device identifier that was used by the implementation

This PR:
- Updates documentation in each OAS
- Adds relevant examples both for when device disambiguation is required, and when it is not required
- Uses `DeviceResponse` object for the device-reachability-status API and for events in the device-reachability-status-subscriptions API to limit device identifiers in responses to exactly one when used
- Removes the IDENTIFIER_MISMATCH error code option from 422 responses

Note; For subscriptions, the `CreateSubscriptionDetail` schema is used in both requests and responses, so modifying the responses to use the `DeviceResponse` would require a general update of the subscription schema in Commonalities. For the moment, the existing schema is left unmodified, which means that multiple device identifiers could be provided in responses, but should not.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #22 

#### Special notes for reviewers:
I think both GET endpoints should never return a device identifier in the responses, but haven't thought through all possible scenarios, so will raise this as a separate issue.

#### Changelog input

```
 release-note
 - Update documentation in each OAS
 - Add relevant examples both for when device disambiguation is required, and when it is not required
-  Use `DeviceResponse` object for the device-reachability-status API and for events in the device-reachability-status-subscriptions API to limit device identifiers in responses to exactly one when used
 - Remove the IDENTIFIER_MISMATCH error code option from 422 responses
```

#### Additional documentation 
None