### PR TITLE
Chore: Reset version numbers to WIP following r1.1

### DIFF
--- a/code/API_definitions/device-reachability-status-subscriptions.yaml
+++ b/code/API_definitions/device-reachability-status-subscriptions.yaml
@@ -123,14 +123,14 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.8.0-rc.1
+  version: wip
   x-camara-commonalities: 0.6
 externalDocs:
   description: Product documentation at CAMARA
   url: https://github.com/camaraproject/DeviceStatus
 
 servers:
-  - url: "{apiRoot}/device-reachability-status-subscriptions/v0.8rc1"
+  - url: "{apiRoot}/device-reachability-status-subscriptions/vwip"
     variables:
       apiRoot:
         default: http://localhost:9091

--- a/code/API_definitions/device-reachability-status.yaml
+++ b/code/API_definitions/device-reachability-status.yaml
@@ -79,14 +79,14 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 1.1.0-rc.2
+  version: wip
   x-camara-commonalities: 0.6
 externalDocs:
   description: Product documentation at CAMARA
   url: https://github.com/camaraproject/DeviceStatus
 
 servers:
-  - url: "{apiRoot}/device-reachability-status/v1rc2"
+  - url: "{apiRoot}/device-reachability-status/vwip"
     variables:
       apiRoot:
         default: http://localhost:9091

--- a/code/Test_definitions/device-reachability-status-subscriptions.feature
+++ b/code/Test_definitions/device-reachability-status-subscriptions.feature
@@ -1,5 +1,5 @@
 @Device_Reachability_Status_Subscription
-Feature: Device Reachability Status Subscriptions API, v0.8.0-rc.1 - Operations createDeviceReachabilityStatusSubscription, retrieveDeviceReachabilityStatusSubscriptionList, retrieveDeviceReachabilityStatusSubscription and deleteDeviceReachabilityStatusSubscription
+Feature: Device Reachability Status Subscriptions API, vwip - Operations createDeviceReachabilityStatusSubscription, retrieveDeviceReachabilityStatusSubscriptionList, retrieveDeviceReachabilityStatusSubscription and deleteDeviceReachabilityStatusSubscription
 
   # Input to be provided by the implementation to the tester
   #
@@ -15,7 +15,7 @@ Feature: Device Reachability Status Subscriptions API, v0.8.0-rc.1 - Operations 
   # References to OAS spec schemas refer to schemas specifies in device-reachability-status-subscriptions.yaml
 
   Background: Common Device Reachability Status Subscriptions setup
-    Given the resource "{apiroot}/device-reachability-status-subscriptions/v0.8rc1" as base-url
+    Given the resource "{apiroot}/device-reachability-status-subscriptions/vwip" as base-url
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
 

--- a/code/Test_definitions/device-reachability-status.feature
+++ b/code/Test_definitions/device-reachability-status.feature
@@ -1,5 +1,5 @@
 @Device_Reachability_Status
-Feature: CAMARA Device reachability status API, v1.1.0-rc.2 - Operation getReachabilityStatus
+Feature: CAMARA Device reachability status API, vwip - Operation getReachabilityStatus
   # Input to be provided by the implementation to the tester
   #
   # Implementation indications:
@@ -12,7 +12,7 @@ Feature: CAMARA Device reachability status API, v1.1.0-rc.2 - Operation getReach
   # References to OAS spec schemas refer to schemas specifies in device-reachability-status.yaml
 
   Background: Common getReachabilityStatus setup
-    Given the resource "{api-root}/device-reachability-status/v1rc2/retrieve" set as base-url
+    Given the resource "{api-root}/device-reachability-status/vwip/retrieve" set as base-url
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"


### PR DESCRIPTION
#### What type of PR is this?
* repository management

#### What this PR does / why we need it:
Version numbers need to be reset to wip following r1.1

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #

#### Special notes for reviewers:
Standard chore following a release

#### Changelog input
```
 release-note
 - Reset version numbers to WIP following r1.1
```

#### Additional documentation 
None