### PR TITLE
Release r1.2 (Fall'25 M4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog DeviceReachabilityStatus
 ## Table of Contents
+- **[r1.2](#r12)**
 - [r1.1](#r11)
 
 **Please be aware that the project will have frequent updates to the main branch. There are no compatibility guarantees associated with code in any branch, including main, until it has been released. For example, changes may be reverted before a release is published. For the best results, use the latest published release.**
@@ -12,6 +13,73 @@ The below sections record the changes for each API version in each release as fo
   - for a public release, the consolidated changes since the previous public release
 
 Note: this API had former releases in the [DeviceStatus](https://github.com/camaraproject/DeviceStatus) repository
+
+# r1.2
+## Release Notes
+
+This public release contains the definition and documentation of
+* device-reachability-status v1.1.0
+* device-reachability-status-subscriptions v0.8.0
+
+The API definition(s) are based on
+* Commonalities v0.6.0 (r3.3)
+* Identity and Consent Management v0.4.0 (r3.3)
+
+## device-reachability-status v1.1.0
+
+device-reachability-status v1.1.0 is a minor update of the API, and is backward compatible with v1.0.0.
+
+- API definition **with inline documentation**:
+  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceReachabilityStatus/r1.2/code/API_definitions/device-reachability-status.yaml&nocors)
+  - [View it on Swagger Editor](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/DeviceReachabilityStatus/r1.2/code/API_definitions/device-reachability-status.yaml)
+  - OpenAPI [YAML spec file](https://github.com/camaraproject/DeviceReachabilityStatus/blob/r1.2/code/API_definitions/device-reachability-status.yaml)
+
+### Added
+
+### Changed
+* Make lastStatusTime mandatory in 200 responses of the API by @eric-murray in https://github.com/camaraproject/DeviceReachabilityStatus/pull/18
+* Update x-correlator schema by @eric-murray in https://github.com/camaraproject/DeviceReachabilityStatus/pull/28
+* Update error response documentation in OAS definitions by @eric-murray in https://github.com/camaraproject/DeviceReachabilityStatus/pull/29
+* Commonalities alignement for device reachability status by @bigludo7 in https://github.com/camaraproject/DeviceReachabilityStatus/pull/36
+* admin: migrate to centralized linting workflows by @hdamker-bot in https://github.com/camaraproject/DeviceReachabilityStatus/pull/39
+* Update error schema for compliance with Commonalities r3.3 by @eric-murray in https://github.com/camaraproject/DeviceReachabilityStatus/pull/43
+
+### Fixed
+* Fix feature files for compliance with centralised linting rules by @eric-murray in https://github.com/camaraproject/DeviceReachabilityStatus/pull/40
+
+### Removed
+* Remove AUTHENTICATION_REQUIRED error code by @eric-murray in https://github.com/camaraproject/DeviceReachabilityStatus/pull/13
+* Update OAS and test definitions to remove IDENTIFIER_MISMATCH error code by @eric-murray in https://github.com/camaraproject/DeviceReachabilityStatus/pull/25
+
+## device-reachability-status-subscriptions v0.8.0
+
+- API definition **with inline documentation**:
+  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceReachabilityStatus/r1.2/code/API_definitions/device-reachability-status-subscriptions.yaml&nocors)
+  - [View it on Swagger Editor](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/DeviceReachabilityStatus/r1.2/code/API_definitions/device-reachability-status-subscriptions.yaml)
+  - OpenAPI [YAML spec file](https://github.com/camaraproject/DeviceReachabilityStatus/blob/r1.2/code/API_definitions/device-reachability-status-subscriptions.yaml)
+
+### Added
+* Add subscription started & updated event by @bigludo7 in https://github.com/camaraproject/DeviceReachabilityStatus/pull/34
+
+### Changed
+* change sink format to format: uri by @maxl2287 in https://github.com/camaraproject/DeviceReachabilityStatus/pull/17
+* Update x-correlator schema by @eric-murray in https://github.com/camaraproject/DeviceReachabilityStatus/pull/28
+* Rename subscription-ends event to subscription-ended by @eric-murray in https://github.com/camaraproject/DeviceReachabilityStatus/pull/30
+* Update error response documentation in OAS definitions by @eric-murray in https://github.com/camaraproject/DeviceReachabilityStatus/pull/29
+* Commonalities alignement for device reachability subscription by @bigludo7 in https://github.com/camaraproject/DeviceReachabilityStatus/pull/36
+* admin: migrate to centralized linting workflows by @hdamker-bot in https://github.com/camaraproject/DeviceReachabilityStatus/pull/39
+* Update error schema for compliance with Commonalities r3.3 by @eric-murray in https://github.com/camaraproject/DeviceReachabilityStatus/pull/43
+
+### Fixed
+* fix: remove "Generic High Entropy Secret" by @maxl2287 in https://github.com/camaraproject/DeviceReachabilityStatus/pull/16
+* Fix feature files for compliance with centralised linting rules by @eric-murray in https://github.com/camaraproject/DeviceReachabilityStatus/pull/40
+
+### Removed
+* Remove AUTHENTICATION_REQUIRED error code by @eric-murray in https://github.com/camaraproject/DeviceReachabilityStatus/pull/13
+* Update OAS and test definitions to remove IDENTIFIER_MISMATCH error code by @eric-murray in https://github.com/camaraproject/DeviceReachabilityStatus/pull/25
+
+**Full Changelog**: https://github.com/camaraproject/DeviceReachabilityStatus/commits/r1.2
+
 # r1.1
 ## Release Notes
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Incubating API Repository to evolve and maintain the definitions and documentati
 
 ## Release Information
 
-The latest public release of the DeviceReachabilityStatus repository is available [here](https://github.com/camaraproject/DeviceReachabilityStatus/releases/latest)
+**NEW**: the latest public release of the DeviceReachabilityStatus repository is available [here](https://github.com/camaraproject/DeviceReachabilityStatus/releases/latest), with the following API versions:**
 
   * **device-reachability-status v1.1.0**  
   [[YAML]](https://github.com/camaraproject/DeviceReachabilityStatus/blob/r1.2/code/API_definitions/device-reachability-status.yaml)

--- a/README.md
+++ b/README.md
@@ -25,12 +25,18 @@ Incubating API Repository to evolve and maintain the definitions and documentati
 
 ## Release Information
 
-The latest public release of the Device Status repository, including the DeviceReachabilityStatus API, is available here: https://github.com/camaraproject/DeviceStatus/releases/latest
-<!-- Optional: an explicit listing of the latest (pre-)release with additional information, e.g. links to the API definitions -->
-<!-- In addition use/uncomment one or multiple the following alternative options when becoming applicable -->
-Pre-releases of this sub project are available in https://github.com/camaraproject/DeviceReachabilityStatus/releases
-<!-- The latest public release is available here: https://github.com/camaraproject/DeviceReachabilityStatus/releases/latest -->
-<!-- For changes see [CHANGELOG.md](https://github.com/camaraproject/DeviceReachabilityStatus/blob/main/CHANGELOG.md) -->
+The latest public release of the DeviceReachabilityStatus repository is available [here](https://github.com/camaraproject/DeviceReachabilityStatus/releases/latest)
+
+  * **device-reachability-status v1.1.0**  
+  [[YAML]](https://github.com/camaraproject/DeviceReachabilityStatus/blob/r1.2/code/API_definitions/device-reachability-status.yaml)
+  [[View it on ReDoc]](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceReachabilityStatus/r1.2/code/API_definitions/device-reachability-status.yaml&nocors)
+  [[View it on Swagger Editor]](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/DeviceReachabilityStatus/r1.2/code/API_definitions/device-reachability-status.yaml)
+  * **device-reachability-status-subscriptions v0.8.0**  
+  [[YAML]](https://github.com/camaraproject/DeviceReachabilityStatus/blob/r1.2/code/API_definitions/device-reachability-status-subscriptions.yaml)
+  [[View it on ReDoc]](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceReachabilityStatus/r1.2/code/API_definitions/device-reachability-status-subscriptions.yaml&nocors)
+  [[View it on Swagger Editor]](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/DeviceReachabilityStatus/r1.2/code/API_definitions/device-reachability-status-subscriptions.yaml)
+
+Pre-releases of this sub project are available [here](https://github.com/camaraproject/DeviceReachabilityStatus/releases). For changes see the [change log](/CHANGELOG.md).
 
 ## Contributing
 

--- a/code/API_definitions/device-reachability-status-subscriptions.yaml
+++ b/code/API_definitions/device-reachability-status-subscriptions.yaml
@@ -477,16 +477,16 @@ components:
           type: string
           format: date-time
           example: 2023-01-17T13:18:23.682Z
-          description: The subscription expiration time (in date-time format) requested by the API consumer. Up to API project decision to keep it.
+          description: The subscription expiration time (in date-time format) requested by the API consumer.
         subscriptionMaxEvents:
           type: integer
-          description: Identifies the maximum number of event reports to be generated (>=1) requested by the API consumer - Once this number is reached, the subscription ends. Up to API project decision to keep it.
+          description: Identifies the maximum number of event reports to be generated (>=1) requested by the API consumer - Once this number is reached, the subscription ends.
           minimum: 1
           example: 5
         initialEvent:
           type: boolean
           description: |
-            Set to `true` by API consumer if consumer wants to get an event as soon as the subscription is created and current situation reflects event request.Up to API project decision to keep it.
+            Set to `true` by API consumer if consumer wants to get an event as soon as the subscription is created and current situation reflects event request.
             Example: Consumer subscribes to reachability SMS. If consumer sets initialEvent to true and device is already reachable by SMS, an event is triggered.
 
     SinkCredential:

--- a/code/API_definitions/device-reachability-status-subscriptions.yaml
+++ b/code/API_definitions/device-reachability-status-subscriptions.yaml
@@ -123,14 +123,14 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: wip
+  version: 0.8.0
   x-camara-commonalities: 0.6
 externalDocs:
   description: Product documentation at CAMARA
-  url: https://github.com/camaraproject/DeviceStatus
+  url: https://github.com/camaraproject/DeviceReachabilityStatus
 
 servers:
-  - url: "{apiRoot}/device-reachability-status-subscriptions/vwip"
+  - url: "{apiRoot}/device-reachability-status-subscriptions/v0.8"
     variables:
       apiRoot:
         default: http://localhost:9091

--- a/code/API_definitions/device-reachability-status-subscriptions.yaml
+++ b/code/API_definitions/device-reachability-status-subscriptions.yaml
@@ -827,7 +827,7 @@ components:
 
     SubscriptionId:
       type: string
-      description: The unique identifier of the subscription in the scope of the subscription manager. When this information is contained within an event notification, this concept SHALL be referred as `subscriptionId` as per [Commonalities Event Notification Model](https://github.com/camaraproject/Commonalities/blob/r2.3/documentation/API-design-guidelines.md#122-event-notification).
+      description: The unique identifier of the subscription in the scope of the subscription manager. When this information is contained within an event notification, this concept SHALL be referred as subscriptionId as per Commonalities Event Notification Model.
       example: qs15-h556-rt89-1298
 
     CloudEvent:

--- a/code/API_definitions/device-reachability-status.yaml
+++ b/code/API_definitions/device-reachability-status.yaml
@@ -79,14 +79,14 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: wip
+  version: 1.1.0
   x-camara-commonalities: 0.6
 externalDocs:
   description: Product documentation at CAMARA
-  url: https://github.com/camaraproject/DeviceStatus
+  url: https://github.com/camaraproject/DeviceReachabilityStatus
 
 servers:
-  - url: "{apiRoot}/device-reachability-status/vwip"
+  - url: "{apiRoot}/device-reachability-status/v1"
     variables:
       apiRoot:
         default: http://localhost:9091

--- a/code/Test_definitions/device-reachability-status-subscriptions-createDeviceReachabilityStatusSubscription.feature
+++ b/code/Test_definitions/device-reachability-status-subscriptions-createDeviceReachabilityStatusSubscription.feature
@@ -15,7 +15,8 @@ Feature: Device Reachability Status Subscriptions API, v0.8.0 - Operation create
   # References to OAS spec schemas refer to schemas specifies in device-reachability-status-subscriptions.yaml
 
   Background: Common Device Reachability Status Subscriptions setup
-    Given the resource "{apiroot}/device-reachability-status-subscriptions/v0.8/subscriptions" as base-url
+    Given an environment at "apiRoot"
+    And the resource "/device-reachability-status-subscriptions/v0.8/subscriptions"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
     And the request body is compliant with the OAS schema at "#/component/schemas/SubscriptionRequest"

--- a/code/Test_definitions/device-reachability-status-subscriptions-createDeviceReachabilityStatusSubscription.feature
+++ b/code/Test_definitions/device-reachability-status-subscriptions-createDeviceReachabilityStatusSubscription.feature
@@ -1,5 +1,5 @@
 # device-reachability-status-subscriptions-createDeviceReachabilityStatusSubscription
-Feature: Device Reachability Status Subscriptions API, vwip - Operation createDeviceReachabilityStatusSubscription
+Feature: Device Reachability Status Subscriptions API, v0.8.0 - Operation createDeviceReachabilityStatusSubscription
 
   # Input to be provided by the implementation to the tester
   #
@@ -15,7 +15,7 @@ Feature: Device Reachability Status Subscriptions API, vwip - Operation createDe
   # References to OAS spec schemas refer to schemas specifies in device-reachability-status-subscriptions.yaml
 
   Background: Common Device Reachability Status Subscriptions setup
-    Given the resource "{apiroot}/device-reachability-status-subscriptions/vwip" as base-url
+    Given the resource "{apiroot}/device-reachability-status-subscriptions/v0.8/subscriptions" as base-url
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
     And the request body is compliant with the OAS schema at "#/component/schemas/SubscriptionRequest"

--- a/code/Test_definitions/device-reachability-status-subscriptions-createDeviceReachabilityStatusSubscription.feature
+++ b/code/Test_definitions/device-reachability-status-subscriptions-createDeviceReachabilityStatusSubscription.feature
@@ -11,6 +11,7 @@ Feature: Device Reachability Status Subscriptions API, v0.8.0 - Operation create
   # * A device object where you can turn on/off the SMS or data usage reachability.
   # * The known reachability status of the testing device
   # * A sink-url identified as "callbackUrl", which receives notifications
+  # * The apiRoot: API root of the server URL
   #
   # References to OAS spec schemas refer to schemas specifies in device-reachability-status-subscriptions.yaml
 

--- a/code/Test_definitions/device-reachability-status-subscriptions-deleteDeviceReachabilityStatusSubscription.feature
+++ b/code/Test_definitions/device-reachability-status-subscriptions-deleteDeviceReachabilityStatusSubscription.feature
@@ -15,7 +15,8 @@ Feature: Device Reachability Status Subscriptions API, v0.8.0 - Operation delete
   # References to OAS spec schemas refer to schemas specifies in device-reachability-status-subscriptions.yaml
 
   Background: Common Device Reachability Status Subscriptions setup
-    Given the resource "{apiroot}/device-reachability-status-subscriptions/v0.8/subscriptions" as base-url
+    Given an environment at "apiRoot"
+    And the resource "/device-reachability-status-subscriptions/v0.8/subscriptions"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
 

--- a/code/Test_definitions/device-reachability-status-subscriptions-deleteDeviceReachabilityStatusSubscription.feature
+++ b/code/Test_definitions/device-reachability-status-subscriptions-deleteDeviceReachabilityStatusSubscription.feature
@@ -11,6 +11,7 @@ Feature: Device Reachability Status Subscriptions API, v0.8.0 - Operation delete
   # * A device object where you can turn on/off the SMS or data usage reachability.
   # * The known reachability status of the testing device
   # * A sink-url identified as "callbackUrl", which receives notifications
+  # * The apiRoot: API root of the server URL
   #
   # References to OAS spec schemas refer to schemas specifies in device-reachability-status-subscriptions.yaml
 

--- a/code/Test_definitions/device-reachability-status-subscriptions-deleteDeviceReachabilityStatusSubscription.feature
+++ b/code/Test_definitions/device-reachability-status-subscriptions-deleteDeviceReachabilityStatusSubscription.feature
@@ -1,5 +1,5 @@
 # device-reachability-status-subscriptions-deleteDeviceReachabilityStatusSubscription
-Feature: Device Reachability Status Subscriptions API, vwip - Operation deleteDeviceReachabilityStatusSubscription
+Feature: Device Reachability Status Subscriptions API, v0.8.0 - Operation deleteDeviceReachabilityStatusSubscription
 
   # Input to be provided by the implementation to the tester
   #
@@ -15,7 +15,7 @@ Feature: Device Reachability Status Subscriptions API, vwip - Operation deleteDe
   # References to OAS spec schemas refer to schemas specifies in device-reachability-status-subscriptions.yaml
 
   Background: Common Device Reachability Status Subscriptions setup
-    Given the resource "{apiroot}/device-reachability-status-subscriptions/vwip" as base-url
+    Given the resource "{apiroot}/device-reachability-status-subscriptions/v0.8/subscriptions" as base-url
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
 

--- a/code/Test_definitions/device-reachability-status-subscriptions-retrieveDeviceReachabilityStatusSubscription.feature
+++ b/code/Test_definitions/device-reachability-status-subscriptions-retrieveDeviceReachabilityStatusSubscription.feature
@@ -1,5 +1,5 @@
 # device-reachability-status-subscriptions-retrieveDeviceReachabilityStatusSubscription
-Feature: Device Reachability Status Subscriptions API, vwip - Operation retrieveDeviceReachabilityStatusSubscription
+Feature: Device Reachability Status Subscriptions API, v0.8.0 - Operation retrieveDeviceReachabilityStatusSubscription
 
   # Input to be provided by the implementation to the tester
   #
@@ -15,7 +15,7 @@ Feature: Device Reachability Status Subscriptions API, vwip - Operation retrieve
   # References to OAS spec schemas refer to schemas specifies in device-reachability-status-subscriptions.yaml
 
   Background: Common Device Reachability Status Subscriptions setup
-    Given the resource "{apiroot}/device-reachability-status-subscriptions/vwip" as base-url
+    Given the resource "{apiroot}/device-reachability-status-subscriptions/v0.8/subscriptions" as base-url
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
 

--- a/code/Test_definitions/device-reachability-status-subscriptions-retrieveDeviceReachabilityStatusSubscription.feature
+++ b/code/Test_definitions/device-reachability-status-subscriptions-retrieveDeviceReachabilityStatusSubscription.feature
@@ -11,6 +11,7 @@ Feature: Device Reachability Status Subscriptions API, v0.8.0 - Operation retrie
   # * A device object where you can turn on/off the SMS or data usage reachability.
   # * The known reachability status of the testing device
   # * A sink-url identified as "callbackUrl", which receives notifications
+  # * The apiRoot: API root of the server URL
   #
   # References to OAS spec schemas refer to schemas specifies in device-reachability-status-subscriptions.yaml
 

--- a/code/Test_definitions/device-reachability-status-subscriptions-retrieveDeviceReachabilityStatusSubscription.feature
+++ b/code/Test_definitions/device-reachability-status-subscriptions-retrieveDeviceReachabilityStatusSubscription.feature
@@ -15,7 +15,8 @@ Feature: Device Reachability Status Subscriptions API, v0.8.0 - Operation retrie
   # References to OAS spec schemas refer to schemas specifies in device-reachability-status-subscriptions.yaml
 
   Background: Common Device Reachability Status Subscriptions setup
-    Given the resource "{apiroot}/device-reachability-status-subscriptions/v0.8/subscriptions" as base-url
+    Given an environment at "apiRoot"
+    And the resource "/device-reachability-status-subscriptions/v0.8/subscriptions"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
 

--- a/code/Test_definitions/device-reachability-status-subscriptions-retrieveDeviceReachabilityStatusSubscriptionList.feature
+++ b/code/Test_definitions/device-reachability-status-subscriptions-retrieveDeviceReachabilityStatusSubscriptionList.feature
@@ -1,5 +1,5 @@
 # device-reachability-status-subscriptions-retrieveDeviceReachabilityStatusSubscriptionList
-Feature: Device Reachability Status Subscriptions API, vwip - Operation retrieveDeviceReachabilityStatusSubscriptionList
+Feature: Device Reachability Status Subscriptions API, v0.8.0 - Operation retrieveDeviceReachabilityStatusSubscriptionList
 
   # Input to be provided by the implementation to the tester
   #
@@ -15,7 +15,7 @@ Feature: Device Reachability Status Subscriptions API, vwip - Operation retrieve
   # References to OAS spec schemas refer to schemas specifies in device-reachability-status-subscriptions.yaml
 
   Background: Common Device Reachability Status Subscriptions setup
-    Given the resource "{apiroot}/device-reachability-status-subscriptions/vwip" as base-url
+    Given the resource "{apiroot}/device-reachability-status-subscriptions/v0.8/subscriptions" as base-url
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
 

--- a/code/Test_definitions/device-reachability-status-subscriptions-retrieveDeviceReachabilityStatusSubscriptionList.feature
+++ b/code/Test_definitions/device-reachability-status-subscriptions-retrieveDeviceReachabilityStatusSubscriptionList.feature
@@ -15,7 +15,8 @@ Feature: Device Reachability Status Subscriptions API, v0.8.0 - Operation retrie
   # References to OAS spec schemas refer to schemas specifies in device-reachability-status-subscriptions.yaml
 
   Background: Common Device Reachability Status Subscriptions setup
-    Given the resource "{apiroot}/device-reachability-status-subscriptions/v0.8/subscriptions" as base-url
+    Given an environment at "apiRoot"
+    And the resource "{apiroot}/device-reachability-status-subscriptions/v0.8/subscriptions"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
 

--- a/code/Test_definitions/device-reachability-status-subscriptions-retrieveDeviceReachabilityStatusSubscriptionList.feature
+++ b/code/Test_definitions/device-reachability-status-subscriptions-retrieveDeviceReachabilityStatusSubscriptionList.feature
@@ -11,6 +11,7 @@ Feature: Device Reachability Status Subscriptions API, v0.8.0 - Operation retrie
   # * A device object where you can turn on/off the SMS or data usage reachability.
   # * The known reachability status of the testing device
   # * A sink-url identified as "callbackUrl", which receives notifications
+  # * The apiRoot: API root of the server URL
   #
   # References to OAS spec schemas refer to schemas specifies in device-reachability-status-subscriptions.yaml
 

--- a/code/Test_definitions/device-reachability-status.feature
+++ b/code/Test_definitions/device-reachability-status.feature
@@ -1,5 +1,5 @@
 # device-reachability-status
-Feature: CAMARA Device reachability status API, vwip - Operation getReachabilityStatus
+Feature: CAMARA Device reachability status API, v1.1.0 - Operation getReachabilityStatus
   # Input to be provided by the implementation to the tester
   #
   # Implementation indications:
@@ -12,7 +12,7 @@ Feature: CAMARA Device reachability status API, vwip - Operation getReachability
   # References to OAS spec schemas refer to schemas specifies in device-reachability-status.yaml
 
   Background: Common getReachabilityStatus setup
-    Given the resource "{api-root}/device-reachability-status/vwip/retrieve" set as base-url
+    Given the resource "{api-root}/device-reachability-status/v1/retrieve" set as base-url
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/device-reachability-status.feature
+++ b/code/Test_definitions/device-reachability-status.feature
@@ -12,7 +12,8 @@ Feature: CAMARA Device reachability status API, v1.1.0 - Operation getReachabili
   # References to OAS spec schemas refer to schemas specifies in device-reachability-status.yaml
 
   Background: Common getReachabilityStatus setup
-    Given the resource "{api-root}/device-reachability-status/v1/retrieve" set as base-url
+    Given an environment at "apiRoot"
+    And the resource "{api-root}/device-reachability-status/v1/retrieve"
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/device-reachability-status.feature
+++ b/code/Test_definitions/device-reachability-status.feature
@@ -8,6 +8,7 @@ Feature: CAMARA Device reachability status API, v1.1.0 - Operation getReachabili
   # Testing assets:
   # * A device object which reachability status is known by the network when connected.
   # * The known reachability status of the testing device
+  # * The apiRoot: API root of the server URL
   #
   # References to OAS spec schemas refer to schemas specifies in device-reachability-status.yaml
 

--- a/documentation/API_documentation/device-reachability-status-API-Readiness-Checklist.md
+++ b/documentation/API_documentation/device-reachability-status-API-Readiness-Checklist.md
@@ -1,22 +1,22 @@
 # API Readiness Checklist
 
-Checklist for device-reachability-status 1.1.0-rc.2 in r1.1.
+Checklist for device-reachability-status 1.1.0 in r1.2
 
 | Nr | API release assets  | alpha | release-candidate |  initial<br>public | stable<br> public | Status | Reference information |
 |----|----------------------------------------------|:-----:|:-----------------:|:-------:|:------:|:----:|:----:|
-|  1 | API definition                               |   M   |         M         |    M    |    M   |   Y   | [/code/API_definitions/device-reachability-status.yaml](/code/API_definitions/device-reachability-status.yaml) |
-|  2 | Design guidelines from Commonalities applied |   O   |         M         |    M    |    M   |   Y   |  [r3.2](https://github.com/camaraproject/Commonalities/releases/tag/r3.2)     |
-|  3 | Guidelines from ICM applied                  |   O   |         M         |    M    |    M   |   Y   |  [r3.2](https://github.com/camaraproject/IdentityAndConsentManagement/releases/tag/r3.2)    |
-|  4 | API versioning convention applied            |   M   |         M         |    M    |    M   |   Y   |      |
-|  5 | API documentation                            |   M   |         M         |    M    |    M   |   Y   | inline in YAML |
-|  6 | User stories                                 |   O   |         O         |    O    |    M   |  Y    |  [/documentation/API_documentation/device-reachability-status-User-Story.md](/documentation/API_documentation/device-reachability-status-User-Story.md)   |
-|  7 | Basic API test cases & documentation         |   O   |         M         |    M    |    M   |   Y | [/code/Test_definitions/device-reachability-status.feature](/code/Test_definitions/device-reachability-status.feature) |
-|  8 | Enhanced API test cases & documentation      |   O   |         O         |    O    |    M   |   Y   |  [/code/Test_definitions/device-reachability-status.feature](/code/Test_definitions/device-reachability-status.feature)   |
-|  9 | Test result statement                        |   O   |         O         |    O    |    M   |   Y   |   na   |
-| 10 | API release numbering convention applied     |   M   |         M         |    M    |    M   |   Y   |      |
-| 11 | Change log updated                           |   M   |         M         |    M    |    M   |   Y   | [/CHANGELOG.md](/CHANGELOG.md) |
-| 12 | Previous public release was certified        |   O   |         O         |    O    |    M   |   Y   |   see (1)   |
-| 13 | API description (for marketing)              |   O   |         O         |    M    |    M   |      | [wiki link](https://lf-camaraproject.atlassian.net/wiki/x/2wHWB) |
+|  1 | API definition                               |   M   |         M         |    M    |    M   |  Y   | [device-reachability-status.yaml](/code/API_definitions/device-reachability-status.yaml) |
+|  2 | Design guidelines from Commonalities applied |   O   |         M         |    M    |    M   |  Y   | [r3.3](https://github.com/camaraproject/Commonalities/releases/tag/r3.3)     |
+|  3 | Guidelines from ICM applied                  |   O   |         M         |    M    |    M   |  Y   | [r3.3](https://github.com/camaraproject/IdentityAndConsentManagement/releases/tag/r3.3)    |
+|  4 | API versioning convention applied            |   M   |         M         |    M    |    M   |  Y   |      |
+|  5 | API documentation                            |   M   |         M         |    M    |    M   |  Y   | inline in YAML |
+|  6 | User stories                                 |   O   |         O         |    O    |    M   |  Y   | [device-reachability-status-User-Story.md](/documentation/API_documentation/device-reachability-status-User-Story.md)   |
+|  7 | Basic API test cases & documentation         |   O   |         M         |    M    |    M   |  Y   | [device-reachability-status.feature](/code/Test_definitions/device-reachability-status.feature) |
+|  8 | Enhanced API test cases & documentation      |   O   |         O         |    O    |    M   |  Y   | [device-reachability-status.feature](/code/Test_definitions/device-reachability-status.feature)   |
+|  9 | Test result statement                        |   O   |         O         |    O    |    M   |  Y   |      |
+| 10 | API release numbering convention applied     |   M   |         M         |    M    |    M   |  Y   |      |
+| 11 | Change log updated                           |   M   |         M         |    M    |    M   |  Y   | [CHANGELOG.md](/CHANGELOG.md) |
+| 12 | Previous public release was certified        |   O   |         O         |    O    |    M   |  Y   | see (1) |
+| 13 | API description (for marketing)              |   O   |         O         |    M    |    M   |  Y   | [wiki link](https://lf-camaraproject.atlassian.net/wiki/x/2wHWB) |
 
 (1) GSMA certified implementations of previous version by multiple operators (source: https://open-gateway.gsma.com/map as of 2025-03-11)
 

--- a/documentation/API_documentation/device-reachability-status-API-Readiness-Checklist.md
+++ b/documentation/API_documentation/device-reachability-status-API-Readiness-Checklist.md
@@ -12,10 +12,10 @@ Checklist for device-reachability-status 1.1.0 in r1.2
 |  6 | User stories                                 |   O   |         O         |    O    |    M   |  Y   | [device-reachability-status-User-Story.md](/documentation/API_documentation/device-reachability-status-User-Story.md)   |
 |  7 | Basic API test cases & documentation         |   O   |         M         |    M    |    M   |  Y   | [device-reachability-status.feature](/code/Test_definitions/device-reachability-status.feature) |
 |  8 | Enhanced API test cases & documentation      |   O   |         O         |    O    |    M   |  Y   | [device-reachability-status.feature](/code/Test_definitions/device-reachability-status.feature)   |
-|  9 | Test result statement                        |   O   |         O         |    O    |    M   |  Y   |      |
+|  9 | Test result statement                        |   O   |         O         |    O    |    M   |  Y   | See [here](https://github.com/camaraproject/DeviceReachabilityStatus/issues/44) |
 | 10 | API release numbering convention applied     |   M   |         M         |    M    |    M   |  Y   |      |
 | 11 | Change log updated                           |   M   |         M         |    M    |    M   |  Y   | [CHANGELOG.md](/CHANGELOG.md) |
-| 12 | Previous public release was certified        |   O   |         O         |    O    |    M   |  Y   | see (1) |
+| 12 | Previous public release was certified        |   O   |         O         |    O    |    M   |  Y   | See (1) |
 | 13 | API description (for marketing)              |   O   |         O         |    M    |    M   |  Y   | [wiki link](https://lf-camaraproject.atlassian.net/wiki/x/2wHWB) |
 
 (1) GSMA certified implementations of previous version by multiple operators (source: https://open-gateway.gsma.com/map as of 2025-03-11)

--- a/documentation/API_documentation/device-reachability-status-subscriptions-API-Readiness-Checklist.md
+++ b/documentation/API_documentation/device-reachability-status-subscriptions-API-Readiness-Checklist.md
@@ -1,22 +1,22 @@
 # API Readiness Checklist
 
-Checklist for device-reachability-status-subscriptions 0.8.0-rc.1 in r1.1.
+Checklist for device-reachability-status-subscriptions 0.8.0 in r1.2
 
 | Nr | API release assets  | alpha | release-candidate |  initial<br>public | stable<br> public | Status | Reference information |
 |----|----------------------------------------------|:-----:|:-----------------:|:-------:|:------:|:----:|:----:|
-|  1 | API definition                               |   M   |         M         |    M    |    M   |   Y   | [/code/API_definitions/device-reachability-status-subscriptions.yaml](/code/API_definitions/device-reachability-status-subscriptions.yaml) |
-|  2 | Design guidelines from Commonalities applied |   O   |         M         |    M    |    M   |   Y   |  [r3.2](https://github.com/camaraproject/Commonalities/releases/tag/r3.2)    |
-|  3 | Guidelines from ICM applied                  |   O   |         M         |    M    |    M   |   Y   |  [r3.2](https://github.com/camaraproject/IdentityAndConsentManagement/releases/tag/r3.2)    |
-|  4 | API versioning convention applied            |   M   |         M         |    M    |    M   |   Y   |      |
-|  5 | API documentation                            |   M   |         M         |    M    |    M   |   Y   | inline in YAML |
-|  6 | User stories                                 |   O   |         O         |    O    |    M   |  N    |      |
-|  7 | Basic API test cases & documentation         |   O   |         M         |    M    |    M   |   Y | [/code/Test_definitions/device-reachability-status-subscriptions.feature](/code/Test_definitions/device-reachability-status-subscriptions.feature) |
-|  8 | Enhanced API test cases & documentation      |   O   |         O         |    O    |    M   |   N   |     |
-|  9 | Test result statement                        |   O   |         O         |    O    |    M   |   N   |     |
-| 10 | API release numbering convention applied     |   M   |         M         |    M    |    M   |   Y   |      |
-| 11 | Change log updated                           |   M   |         M         |    M    |    M   |   Y   | [/CHANGELOG.md](/CHANGELOG.md) |
-| 12 | Previous public release was certified        |   O   |         O         |    O    |    M   |   N   |      |
-| 13 | API description (for marketing)              |   O   |         O         |    M    |    M   |      | [wiki link](https://lf-camaraproject.atlassian.net/wiki/x/JAFmBQ) |
+|  1 | API definition                               |   M   |         M         |    M    |    M   |  Y   | [device-reachability-status-subscriptions.yaml](/code/API_definitions/device-reachability-status-subscriptions.yaml) |
+|  2 | Design guidelines from Commonalities applied |   O   |         M         |    M    |    M   |  Y   | [r3.3](https://github.com/camaraproject/Commonalities/releases/tag/r3.3)    |
+|  3 | Guidelines from ICM applied                  |   O   |         M         |    M    |    M   |  Y   | [r3.3](https://github.com/camaraproject/IdentityAndConsentManagement/releases/tag/r3.3)    |
+|  4 | API versioning convention applied            |   M   |         M         |    M    |    M   |  Y   |      |
+|  5 | API documentation                            |   M   |         M         |    M    |    M   |  Y   | inline in YAML |
+|  6 | User stories                                 |   O   |         O         |    O    |    M   |  N   |      |
+|  7 | Basic API test cases & documentation         |   O   |         M         |    M    |    M   |  Y   | [device-reachability-status-subscriptions.feature](/code/Test_definitions/device-reachability-status-subscriptions.feature) |
+|  8 | Enhanced API test cases & documentation      |   O   |         O         |    O    |    M   |  N   |      |
+|  9 | Test result statement                        |   O   |         O         |    O    |    M   |  N   |      |
+| 10 | API release numbering convention applied     |   M   |         M         |    M    |    M   |  Y   |      |
+| 11 | Change log updated                           |   M   |         M         |    M    |    M   |  Y   | [CHANGELOG.md](/CHANGELOG.md) |
+| 12 | Previous public release was certified        |   O   |         O         |    O    |    M   |  N   |      |
+| 13 | API description (for marketing)              |   O   |         O         |    M    |    M   |  Y   | [wiki link](https://lf-camaraproject.atlassian.net/wiki/x/JAFmBQ) |
 
 Note: the checklists of a public API version and of its preceding release-candidate API version can be the same.
 


### PR DESCRIPTION
#### What type of PR is this?
* subproject management

#### What this PR does / why we need it:
Publication of Fall'25 M4 public release of:
- device-reachability-status v1.1.0
- device-reachability-status-subscriptions v0.8.0

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #38 

#### Special notes for reviewers:
None

#### Changelog input
```
 release-note
 - Publication of Fall'25 M4 public release of device-reachability-status v1.1.0 and device-reachability-status-subscriptions v0.8.0
```

#### Additional documentation 
None