### PR TITLE
Clarify LastStatusTime description in YAML

### DIFF
--- a/code/API_definitions/device-reachability-status.yaml
+++ b/code/API_definitions/device-reachability-status.yaml
@@ -188,9 +188,8 @@ components:
   schemas:
     LastStatusTime:
       description: |
-        Last time that the associated device reachability status was updated.
+        The last time that the device reachability status was confirmed to be correct by the API provider. The status should still be valid, but the API provider is unable to confirm this.
         It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
-        Recommended format is yyyy-MM-dd'T'HH:mm:ss.SSSZ (i.e. which allows 2023-07-03T14:27:08.312+02:00 or 2023-07-03T12:27:08.312Z)
       type: string
       format: date-time
       example: "2024-02-20T10:41:38.657Z"


### PR DESCRIPTION
#### What type of PR is this?
* correction

#### What this PR does / why we need it:
Updated the description of LastStatusTime to clarify the confirmation of device reachability status by the API provider.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #50 

#### Special notes for reviewers:
None

#### Changelog input

```
 release-note
 - Clarify LastStatusTime description in YAML
```

#### Additional documentation 
None